### PR TITLE
Support strawberry perl 5.26

### DIFF
--- a/hints/MSWin32.pl
+++ b/hints/MSWin32.pl
@@ -1,3 +1,9 @@
 use Config;
-$self->{LIBS} = ['-lssleay32 -llibeay32'] if $Config{cc} =~ /cl/; # msvc with ActivePerl
-$self->{LIBS} = ['-lssl32 -leay32']       if $Config{gccversion}; # gcc
+if (my $libs = `pkg-config --libs libssl libcrypto 2>nul`) {
+  # strawberry perl has pkg-config
+  $self->{LIBS} = [ $libs ];
+}
+else {
+  $self->{LIBS} = ['-lssleay32 -llibeay32'] if $Config{cc} =~ /cl/; # msvc with ActivePerl
+  $self->{LIBS} = ['-lssl32 -leay32']       if $Config{gccversion}; # gcc
+}


### PR DESCRIPTION
Crypt::OpenSSL::Random failed to install on strawberry perl 5.26 at [CPAN Testers](http://matrix.cpantesters.org/?dist=Crypt-OpenSSL-Random%200.14;os=mswin32;perl=5.26.0;reports=1).
This PR applies the patch from strawberry perl's: http://strawberryperl.com/package/kmx/perl-modules-patched/Crypt-OpenSSL-Random-0.11_patched.diff