### PR TITLE
Add missing library path on Windows and support CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ perl:
   - 5.24.2
   - 5.26.1
 before_install:
+  - export AUTOMATED_TESTING=1
   - eval $(curl https://travis-perl.github.io/init) --auto
   - build-perl
   - perl -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: perl
+sudo: false
+branches:
+  except:
+    - /issue\d+/
+perl:
+  - 5.8.1
+  - 5.8.3
+  - 5.8.6
+  - 5.8.7
+  - 5.8.8
+  - 5.8.9
+  - 5.10.1
+  - 5.12.3
+  - 5.14.4
+  - 5.16.3
+  - 5.18.4
+  - 5.20.3
+  - 5.22.3
+  - 5.24.2
+  - 5.26.1
+before_install:
+  - eval $(curl https://travis-perl.github.io/init) --auto
+  - build-perl
+  - perl -V
+  - build-dist
+  - cd $BUILD_DIR
+install:
+  - export AUTOMATED_TESTING=1 HARNESS_TIMER=1 AUTHOR_TESTING=1 RELEASE_TESTING=1
+  - cpanm --notest Crypt::OpenSSL::Guess
+  - cpanm --installdeps --notest .

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -38,7 +38,7 @@ WriteMakefile(
       },
      }
     ) : ()),
-    SIGN => 1
+    ($ENV{AUTOMATED_TESTING} ? () : (SIGN => 1)),
 );
 
 package MY;

--- a/appveyor.cmd
+++ b/appveyor.cmd
@@ -1,0 +1,71 @@
+@echo off
+call :%*
+goto :eof
+
+:perl_setup
+if not defined perl_type set perl_type=system
+if "%perl_type%" == "cygwin" (
+  start /wait c:\cygwin\setup-x86.exe -q -g -P perl -P make -P gcc -P gcc-g++ -P libcrypt-devel
+  set "PATH=C:\cygwin\usr\local\bin;C:\cygwin\bin;%PATH%"
+) else if "%perl_type%" == "strawberry" (
+  if not defined perl_version (
+    cinst -y StrawberryPerl
+  ) else (
+    cinst -y StrawberryPerl --version %perl_version%
+  )
+  if errorlevel 1 (
+    type C:\ProgramData\chocolatey\logs\chocolatey.log
+    exit /b 1
+  )
+  set "PATH=C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;%PATH%"
+) else if "%perl_type%" == "system" (
+  mkdir c:\dmake
+  cinst -y curl
+  curl http://www.cpan.org/authors/id/S/SH/SHAY/dmake-4.12.2.2.zip -o c:\dmake\dmake.zip
+  7z x c:\dmake\dmake.zip -oc:\ >NUL
+  set "PATH=c:\dmake;C:\MinGW\bin;%PATH%"
+) else (
+  echo.Unknown perl type "%perl_type%"! 1>&2
+  exit /b 1
+)
+for /f "usebackq delims=" %%d in (`perl -MConfig -e"print $Config{make}"`) do set "make=%%d"
+set "perl=perl"
+set "cpanm=call appveyor.cmd cpanm"
+set "cpan=%perl% -S cpan"
+set TAR_OPTIONS=--warning=no-unknown-keyword
+goto :eof
+
+:cpanm
+%perl% -S cpanm >NUL 2>&1
+if ERRORLEVEL 1 (
+  curl -V >NUL 2>&1
+  if ERRORLEVEL 1 cinst -y curl
+  curl -k -L https://cpanmin.us/ -o "%TEMP%\cpanm"
+  %perl% "%TEMP%\cpanm" -n App::cpanminus
+)
+set "cpanm=%perl% -S cpanm"
+%cpanm% %*
+goto :eof
+
+:local_lib
+if "%perl_type%" == "cygwin" goto :local_lib_cygwin
+%perl% -Ilib -Mlocal::lib=--shelltype=cmd %* > %TEMP%\local-lib.bat
+call %TEMP%\local-lib.bat
+del %TEMP%\local-lib.bat
+goto :eof
+
+:local_lib_cygwin
+for /f "usebackq delims=" %%d in (`sh -c "cygpath -w $HOME/perl5"`) do (
+  c:\perl\bin\perl.exe -Ilib -Mlocal::lib - %%d --shelltype=cmd > "%TEMP%\local-lib.bat"
+)
+setlocal
+  call "%TEMP%\local-lib.bat"
+endlocal & set "PATH=%PATH%"
+set "PATH_BACK=%PATH%"
+%perl% -Ilib -Mlocal::lib - --shelltype=cmd > "%TEMP%\local-lib.bat"
+call "%TEMP%\local-lib.bat"
+set "PATH=%PATH_BACK%"
+del "%TEMP%\local-lib.bat"
+goto :eof
+
+:eof

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+version: '{build}'
+shallow_clone: true
+
+environment:
+  matrix:
+    - perl_type: system
+    - perl_type: cygwin
+    - perl_type: strawberry
+    - perl_type: strawberry
+      perl_version: 5.24.3.1
+    - perl_type: strawberry
+      perl_version: 5.20.3.3
+    - perl_type: strawberry
+      perl_version: 5.18.4.1
+install:
+  # use strawberry perl's OpenSSL, remove AppVeyor's buildin OpenSSL-Win32
+  - cmd: if [%perl_type%]==[strawberry] (
+      rd /s /q C:\OpenSSL-Win32 )
+  - cmd: if [%perl_type%]==[cygwin] (
+      C:\cygwin\setup-x86.exe -qgnNdO -l C:\cygwin\var\cache\setup -R c:\cygwin -s http://cygwin.mirror.constant.com -P openssl-devel )
+
+  - 'call appveyor.cmd perl_setup'
+  - '%perl% -V'
+  - '%cpanm% -n Crypt::OpenSSL::Guess'
+  - '%cpanm% --installdeps -n --with-develop --with-recommends .'
+
+build: off
+
+test_script:
+  - '%perl% Makefile.PL && %make% test'
+
+matrix:
+ fast_finish: true

--- a/hints/MSWin32.pl
+++ b/hints/MSWin32.pl
@@ -1,9 +1,10 @@
 use Config;
+use Crypt::OpenSSL::Guess 0.11 qw(openssl_lib_paths);
 if (my $libs = `pkg-config --libs libssl libcrypto 2>nul`) {
   # strawberry perl has pkg-config
-  $self->{LIBS} = [ $libs ];
+  $self->{LIBS} = [openssl_lib_paths() . " $libs"];
 }
 else {
-  $self->{LIBS} = ['-lssleay32 -llibeay32'] if $Config{cc} =~ /cl/; # msvc with ActivePerl
-  $self->{LIBS} = ['-lssl32 -leay32']       if $Config{gccversion}; # gcc
+  $self->{LIBS} = [openssl_lib_paths() . '-lssleay32 -llibeay32'] if $Config{cc} =~ /cl/; # msvc with ActivePerl
+  $self->{LIBS} = [openssl_lib_paths() . '-lssl32 -leay32']       if $Config{gccversion}; # gcc
 }

--- a/t/z_pod-coverage.t
+++ b/t/z_pod-coverage.t
@@ -3,7 +3,10 @@ use strict;
 use warnings;
 use Test::More;
 
-plan skip_all => 'done_testing requires Test::More 0.88' if Test::More->VERSION < 0.88;
+BEGIN {
+    plan skip_all => 'done_testing requires Test::More 0.88' if Test::More->VERSION < 0.88;
+}
+
 plan skip_all => 'This test is only run for the module author'
     unless -d '.git' || $ENV{IS_MAINTAINER};
 


### PR DESCRIPTION
- set library path with `openssl_lib_paths` in `hints/MSWin32.pl`
- support Travis and AppVeyor CI
  - I tested in my repository, results are [Travis](https://travis-ci.org/akiym/Crypt-OpenSSL-Random/builds/370059749) and [AppVeyor](https://ci.appveyor.com/project/akiym/crypt-openssl-random/build/19)
  - @rurban Could you enable these CI in your repository?
- fix `t/z_pod-coverage.t` failed on perl-5.8