### PR TITLE
More explicit RAND_bytes() return value check

### DIFF
--- a/Random.xs
+++ b/Random.xs
@@ -22,7 +22,7 @@ PPCODE:
             PACKAGE_NAME);
     }
 
-    if(RAND_bytes(rand_bytes, num_bytes))
+    if(RAND_bytes(rand_bytes, num_bytes) == 1)
     {
       XPUSHs(sv_2mortal(newSVpv((const char*)rand_bytes, num_bytes)));
         Safefree(rand_bytes);
@@ -47,7 +47,7 @@ PPCODE:
             PACKAGE_NAME);
     }
 
-    if(RAND_bytes(rand_bytes, num_bytes))
+    if(RAND_bytes(rand_bytes, num_bytes) == 1)
     {
         XPUSHs(sv_2mortal(newSVpv((const char*)rand_bytes, num_bytes)));
         Safefree(rand_bytes);


### PR DESCRIPTION
RAND_bytes() may return -1 in a specific error condition, which
the current check would mistake for a success.

Explicitly only consider RAND_bytes() == 1 as a success.